### PR TITLE
Add secure ChatGPT Work tunnel setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,45 @@ claude mcp add substack-mcp --scope user -- /Users/$USER/substack/.venv/bin/subs
 
 Restart Claude Code, then `/mcp` should show `substack-mcp` as `connected`.
 
+### Connect to ChatGPT Work with Secure MCP Tunnel
+
+This server uses the local `substack.sid` browser session and should not be
+published directly on the internet. For a private ChatGPT Work connection, use
+[OpenAI Secure MCP Tunnel](https://developers.openai.com/api/docs/guides/secure-mcp-tunnels).
+The tunnel keeps the stdio MCP and Substack credential on your Mac while making
+the tools available to an authorized ChatGPT workspace.
+
+Prerequisites:
+
+- macOS with Chrome, Brave, Edge, Chromium, Vivaldi, or Opera already signed in
+  to Substack
+- ChatGPT developer mode enabled
+- an OpenAI Platform tunnel ID associated with the target ChatGPT workspace
+- `tunnel-client` installed from OpenAI Platform tunnel settings
+- a tunnel runtime API key with **Tunnels Read + Use** permission
+
+Run:
+
+```bash
+git clone https://github.com/nanameru/substack-mcp.git
+cd substack-mcp
+
+# Keep these values out of shell history when possible. Never commit them.
+export SUBSTACK_TUNNEL_ID="tunnel_..."
+export CONTROL_PLANE_API_KEY="sk-..."
+
+./scripts/setup-chatgpt-work-tunnel.sh
+tunnel-client run --profile substack-mcp
+```
+
+Then open ChatGPT Plugins, create a developer-mode app, choose **Tunnel** under
+Connection, and select the tunnel. The Mac and `tunnel-client` process must stay
+running while ChatGPT calls the Substack tools.
+
+The helper never prints or uploads the Substack session token. It runs
+`substack-mcp-setup` locally, stores the credential with `0600` permissions, and
+points the tunnel at the local stdio command.
+
 ### (Optional) Install the `substack-article` skill
 
 This repo also ships a [Vercel Skills](https://skills.sh/)-compatible **agent skill**

--- a/scripts/setup-chatgpt-work-tunnel.sh
+++ b/scripts/setup-chatgpt-work-tunnel.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROFILE_NAME="${SUBSTACK_TUNNEL_PROFILE:-substack-mcp}"
+REPO_DIR="${SUBSTACK_MCP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+VENV_DIR="${REPO_DIR}/.venv"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This helper is intended for macOS because Substack authentication is read from a local browser session." >&2
+  exit 1
+fi
+
+if [[ -z "${SUBSTACK_TUNNEL_ID:-}" ]]; then
+  echo "Set SUBSTACK_TUNNEL_ID to the tunnel ID created in OpenAI Platform settings." >&2
+  exit 1
+fi
+
+if [[ -z "${CONTROL_PLANE_API_KEY:-}" ]]; then
+  echo "Set CONTROL_PLANE_API_KEY to the runtime API key created for tunnel-client." >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required." >&2
+  exit 1
+fi
+
+if ! command -v tunnel-client >/dev/null 2>&1; then
+  echo "tunnel-client is required. Download it from OpenAI Platform tunnel settings." >&2
+  exit 1
+fi
+
+python3 -m venv "${VENV_DIR}"
+"${VENV_DIR}/bin/python" -m pip install --upgrade pip
+"${VENV_DIR}/bin/pip" install -e "${REPO_DIR}"
+
+echo "Opening the local Substack authentication setup. No session token is printed or uploaded by this script."
+"${VENV_DIR}/bin/substack-mcp-setup"
+
+tunnel-client init \
+  --sample sample_mcp_stdio_local \
+  --profile "${PROFILE_NAME}" \
+  --tunnel-id "${SUBSTACK_TUNNEL_ID}" \
+  --mcp-command "${VENV_DIR}/bin/substack-mcp"
+
+tunnel-client doctor --profile "${PROFILE_NAME}" --explain
+
+echo
+echo "Setup complete. Keep the following process running while ChatGPT Work uses Substack:"
+echo "tunnel-client run --profile ${PROFILE_NAME}"
+


### PR DESCRIPTION
## Summary

- document the official Secure MCP Tunnel path for connecting the local stdio server to ChatGPT Work
- add a macOS setup helper that installs the package, runs local Substack authentication, initializes the tunnel profile, and validates it
- keep Substack session credentials local; no cookie or API key is committed

## Validation

- `bash -n scripts/setup-chatgpt-work-tunnel.sh`
- `git diff --check`

## Notes

The Mac and `tunnel-client` process must stay running while ChatGPT uses the Substack MCP tools.